### PR TITLE
Add minimal AI crawling and SEO discoverability support

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,3 @@
+/
+  Link: </llms.txt>; rel="service-doc"
+  Link: </sitemap.xml>; rel="sitemap"

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,44 @@
+User-agent: *
+Allow: /
+Content-Signal: search=yes, ai-input=yes, ai-train=no
+
+User-agent: GPTBot
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: anthropic-ai
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: claude-web
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Perplexity-User
+Allow: /
+
+User-agent: cohere-ai
+Allow: /
+
+User-agent: Bytespider
+Allow: /
+
+User-agent: FacebookBot
+Allow: /
+
+User-agent: meta-externalagent
+Allow: /
+
+Sitemap: https://mehmetraufoguz.com/sitemap.xml

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vocs/config'
 
 export default defineConfig({
   renderStrategy: 'full-static',
+  baseUrl: 'https://mehmetraufoguz.com',
   title: 'Rauf',
   description: 'Portfolio',
   colorScheme: 'light dark',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Improves AI crawler discoverability and core SEO for the portfolio without adding MCP, OAuth, or other agent-platform features.

## Changes

- **`vocs.config.ts`** — set `baseUrl: 'https://mehmetraufoguz.com'` so Vocs emits canonical URLs and generates `sitemap.xml` at build time
- **`public/robots.txt`** — valid crawler directives with explicit AI bot allow rules and Content Signals (`search=yes`, `ai-input=yes`, `ai-train=no`)
- **`public/_headers`** — Cloudflare Pages headers adding `Link` discovery for `llms.txt` and `sitemap.xml` on `/`

## Expected impact after deploy

| Check | Before | After (expected) |
|---|---|---|
| robots.txt | Fail (no User-agent) | Pass |
| sitemap.xml | Fail | Pass |
| AI bot rules | Fail | Pass |
| Content Signals | Fail | Pass |
| Link headers | Fail | Pass |
| Canonical URLs | Missing | Present |

## Notes

- `_headers` is applied by Cloudflare Pages at the edge after deploy
- Markdown content negotiation is unchanged (requires server runtime; not needed for this minimal plan)
- DNS-AID, MCP, and commerce checks are intentionally out of scope
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2c93-4eaf-7c5b-ad50-a28e8500b5e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2c93-4eaf-7c5b-ad50-a28e8500b5e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

