### PR TITLE
Add scoped sidebars for projects and blog sections

### DIFF
--- a/src/sidebar.config.ts
+++ b/src/sidebar.config.ts
@@ -1,0 +1,31 @@
+import { blogPosts, projects, sortByDateDesc } from './pages/_components/content'
+
+const mainSidebar = [
+  { text: 'Home', link: '/' },
+  { text: 'Projects', link: '/projects' },
+  { text: 'Blog', link: '/blog' },
+] as const
+
+export default {
+  '/': mainSidebar,
+  '/projects': {
+    backLink: true,
+    items: [
+      { text: 'All Projects', link: '/projects' },
+      ...sortByDateDesc(projects).map((project) => ({
+        text: project.title,
+        link: `/projects/${project.slug}`,
+      })),
+    ],
+  },
+  '/blog': {
+    backLink: true,
+    items: [
+      { text: 'All Posts', link: '/blog' },
+      ...sortByDateDesc(blogPosts).map((post) => ({
+        text: post.title,
+        link: `/blog/${post.slug}`,
+      })),
+    ],
+  },
+}

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig } from 'vocs/config'
 
+import sidebar from './src/sidebar.config'
+
 export default defineConfig({
   renderStrategy: 'full-static',
   title: 'Rauf',
@@ -10,11 +12,7 @@ export default defineConfig({
     { text: 'Projects', link: '/projects' },
     { text: 'Blog', link: '/blog' },
   ],
-  sidebar: [
-    { text: 'Home', link: '/' },
-    { text: 'Projects', link: '/projects' },
-    { text: 'Blog', link: '/blog' },
-  ],
+  sidebar,
   socials: [
     { icon: 'github', link: 'https://github.com/mehmetraufoguz' },
     { icon: 'telegram', link: 'https://t.me/mehmetraufoguz' },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Scopes the sidebar by section while keeping the main nav on the homepage.

- **`/`** — Home, Projects, Blog
- **`/projects/*`** — All Projects + project list (newest first)
- **`/blog/*`** — All Posts + blog list (newest first)

Lists are generated from `content.ts` automatically.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2c3a-9f31-7c8d-b7c4-19b72a274257"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2c3a-9f31-7c8d-b7c4-19b72a274257"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

